### PR TITLE
feat: wire release workflow to shared reusable workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Release Please Workflow
+name: Release Workflow
 
 on:
   push:
@@ -12,19 +12,31 @@ permissions:
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created }}
+      tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
       - uses: googleapis/release-please-action@v4
         id: release
         with:
-          # this assumes that you have created a personal access token
-          # (PAT) and configured it as a GitHub action secret named
-          # `MY_RELEASE_PLEASE_TOKEN` (this secret name is not important).
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ github.token }}
           config-file: .github/release-please/release-please-config.json
           manifest-file: .github/release-please/.release-please-manifest.json
-          # this is a built-in strategy in release-please, see "Action Inputs"
-          # for more options
-          # release-type: simple
 
-          
+  improve-release-notes:
+    needs: release-please
+    if: ${{ needs.release-please.outputs.release_created }}
+    uses: ScottKirvan/BojuStudio_devops_agent/.github/workflows/reusable-release-notes.yml@main
+    with:
+      tag_name: ${{ needs.release-please.outputs.tag_name }}
+      project_context: "ReleasePleaseTest is a sandbox repo for testing shared GitHub Actions workflows and release automation patterns."
+    secrets: inherit
 
+  discord-notify:
+    needs: [release-please, improve-release-notes]
+    if: ${{ needs.release-please.outputs.release_created }}
+    uses: ScottKirvan/BojuStudio_devops_agent/.github/workflows/reusable-discord-notify.yml@main
+    with:
+      tag_name: ${{ needs.release-please.outputs.tag_name }}
+      project_name: ReleasePleaseTest
+    secrets: inherit


### PR DESCRIPTION
## Summary
- Replaced inline release-please boilerplate with a clean caller workflow
- Wires `improve-release-notes` job → `ScottKirvan/BojuStudio_devops_agent/.github/workflows/reusable-release-notes.yml@main`
- Wires `discord-notify` job → `ScottKirvan/BojuStudio_devops_agent/.github/workflows/reusable-discord-notify.yml@main`

## Test plan
- [ ] Merge BojuStudio_devops_agent reusable library PR first
- [ ] Merge this PR
- [ ] Make a `feat:` commit to trigger a release-please PR, merge it, then verify: release created → notes rewritten by AI → Discord notified
- [ ] Confirm `DISCORD_WEBHOOK` secret is set in this repo's Actions secrets