### PR TITLE
fix: update reusable workflow refs to ScottKirvan/.github

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
   improve-release-notes:
     needs: release-please
     if: ${{ needs.release-please.outputs.release_created }}
-    uses: ScottKirvan/BojuStudio_devops_agent/.github/workflows/reusable-release-notes.yml@main
+    uses: ScottKirvan/.github/.github/workflows/reusable-release-notes.yml@main
     with:
       tag_name: ${{ needs.release-please.outputs.tag_name }}
       project_context: "ReleasePleaseTest is a sandbox repo for testing shared GitHub Actions workflows and release automation patterns."
@@ -35,7 +35,7 @@ jobs:
   discord-notify:
     needs: [release-please, improve-release-notes]
     if: ${{ needs.release-please.outputs.release_created }}
-    uses: ScottKirvan/BojuStudio_devops_agent/.github/workflows/reusable-discord-notify.yml@main
+    uses: ScottKirvan/.github/.github/workflows/reusable-discord-notify.yml@main
     with:
       tag_name: ${{ needs.release-please.outputs.tag_name }}
       project_name: ReleasePleaseTest


### PR DESCRIPTION
## Summary
Updates `uses:` references from the private `BojuStudio_devops_agent` repo to the public `ScottKirvan/.github` repo, fixing the workflow file error caused by cross-visibility reusable workflow restrictions.

## Test plan
- [ ] Merge ScottKirvan/.github PR first
- [ ] Merge this PR
- [ ] Make a `feat:` commit to trigger a release-please PR, merge it, verify: release created → AI notes rewrite → Discord notified