### PR TITLE
fix: add models: read permission for AI release notes workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  models: read
 
 jobs:
   release-please:


### PR DESCRIPTION
## Summary
The `reusable-release-notes.yml` workflow declares `models: read` permission (required by `actions/ai-inference`). GitHub validates at startup that the caller's workflow grants every permission the callee declares — causing `startup_failure` when it's missing.

## Test plan
- [ ] Merge and verify the next push no longer produces a startup_failure