### PR TITLE
feat: pass project_name to updated release-notes workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,7 @@ jobs:
     uses: ScottKirvan/.github/.github/workflows/reusable-release-notes.yml@main
     with:
       tag_name: ${{ needs.release-please.outputs.tag_name }}
+      project_name: "ReleasePleaseTest"
       project_context: "ReleasePleaseTest is a sandbox repo for testing shared GitHub Actions workflows and release automation patterns."
     secrets: inherit
 


### PR DESCRIPTION
## Summary
Passes the new required `project_name` input to `reusable-release-notes.yml`.

## Test plan
- [ ] Merge ScottKirvan/.github PR first
- [ ] Merge this, make a `feat:` commit to trigger a release-please PR, verify categorized notes