### PR TITLE
fix: add project_name, header, and footer to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,15 @@ jobs:
       tag_name: ${{ needs.release-please.outputs.tag_name }}
       project_name: "ReleasePleaseTest"
       project_context: "ReleasePleaseTest is a sandbox repo for testing shared GitHub Actions workflows and release automation patterns."
+      header: |
+        ## ReleasePleaseTest
+
+        > Sandbox repo for validating shared workflow patterns across the BojuStudio ecosystem.
+
+        ---
+      footer: |
+        ---
+        🔧 [Workflow Source](https://github.com/ScottKirvan/.github) · 🐛 [Report an Issue](https://github.com/ScottKirvan/ReleasePleaseTest/issues/new) · 💬 [Discord](https://discord.gg/TSKHvVFYxB)
     secrets: inherit
 
   discord-notify:
@@ -40,5 +49,5 @@ jobs:
     uses: ScottKirvan/.github/.github/workflows/reusable-discord-notify.yml@main
     with:
       tag_name: ${{ needs.release-please.outputs.tag_name }}
-      project_name: ReleasePleaseTest
+      project_name: "ReleasePleaseTest"
     secrets: inherit


### PR DESCRIPTION
## Summary
Supersedes #41. Adds `project_name`, stub `header`, and stub `footer` inputs to the `improve-release-notes` job, testing the full header/footer assembly in `reusable-release-notes.yml`.

## Testing

**Prerequisite:** ScottKirvan/.github PR #3 must be merged first (adds header/footer inputs to the reusable workflow).

**Steps to verify:**
1. Merge this PR
2. Make any `fix:` commit to trigger a release-please PR (or merge an existing one)
3. Merge the release-please PR — this triggers the full release chain
4. Check the GitHub release page for the new tag
5. Check Discord

**Expected result:**
- GitHub release body shows:
  - Header: `## ReleasePleaseTest` + description + `---`
  - Body: AI-written bullet points sorted into `### What's New` and/or `### Bug Fixes`
  - Footer: `---` + links to workflow source, issues, Discord
- Discord message shows the AI-written notes (reads from the updated release body)
- Project is named "ReleasePleaseTest" throughout — not "BojuBot"

**Test environment:** GitHub Actions / ScottKirvan/ReleasePleaseTest