### PR TITLE
fix: remove workflow source link from release footer

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
         ---
       footer: |
         ---
-        🐛 [Report an Issue](https://github.com/ScottKirvan/ReleasePleaseTest/issues/new) · 💬 [Discord](https://discord.gg/TSKHvVFYxB)
+        🐛 [Report an Issue](https://github.com/ScottKirvan/ReleasePleaseTest/issues/new) · 💬 [Discord](https://discord.gg/TN6XJSNK5Y)
     secrets: inherit
 
   discord-notify:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
         ---
       footer: |
         ---
-        🔧 [Workflow Source](https://github.com/ScottKirvan/.github) · 🐛 [Report an Issue](https://github.com/ScottKirvan/ReleasePleaseTest/issues/new) · 💬 [Discord](https://discord.gg/TSKHvVFYxB)
+        🐛 [Report an Issue](https://github.com/ScottKirvan/ReleasePleaseTest/issues/new) · 💬 [Discord](https://discord.gg/TSKHvVFYxB)
     secrets: inherit
 
   discord-notify:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,15 @@ jobs:
       tag_name: ${{ needs.release-please.outputs.tag_name }}
       project_name: "ReleasePleaseTest"
       project_context: "ReleasePleaseTest is a sandbox repo for testing shared GitHub Actions workflows and release automation patterns."
+      header: |
+        ## ReleasePleaseTest
+
+        > Sandbox repo for validating shared workflow patterns across the BojuStudio ecosystem.
+
+        ---
+      footer: |
+        ---
+        🔧 [Workflow Source](https://github.com/ScottKirvan/.github) · 🐛 [Report an Issue](https://github.com/ScottKirvan/ReleasePleaseTest/issues/new) · 💬 [Discord](https://discord.gg/TSKHvVFYxB)
     secrets: inherit
 
   discord-notify:
@@ -40,5 +49,5 @@ jobs:
     uses: ScottKirvan/.github/.github/workflows/reusable-discord-notify.yml@main
     with:
       tag_name: ${{ needs.release-please.outputs.tag_name }}
-      project_name: ReleasePleaseTest
+      project_name: "ReleasePleaseTest"
     secrets: inherit

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Contributions / Contact
 -----------------------
 - Please [file an issue](https://github.com/ScottKirvan/ScooterGitTemplate/issues/), or grab a fork, hack away, and submit some [pull requests](https://github.com/ScottKirvan/ScooterGitTemplate/pulls).
 - Contact me at [linkedin.com/in/scottkirvan/](https://www.linkedin.com/in/scottkirvan/)
-- You can also contact me at my [discord](https://discord.gg/TSKHvVFYxB) server, I'm cptvideo.
+- You can also contact me at my [discord](https://discord.gg/TN6XJSNK5Y) server, I'm cptvideo.
 
 Credits
 -------


### PR DESCRIPTION
## Summary
- Removes `🔧 Workflow Source` link from release note footer
- That link points to internal devops infrastructure — meaningless to end users
- Keeps Report an Issue and Discord links

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Testing
**Steps to verify:**
1. Merge this PR
2. Let release-please create and merge a release PR
3. Check the GitHub release — footer should show only Issue and Discord links

**Expected result:** No workflow source link in published release notes.

**Test environment:**
- GitHub release page

## Checklist
- [x] I have performed a self-review of my own code