### PR TITLE
fix: add update-changelog-prs job to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,13 @@ jobs:
         🐛 [Report an Issue](https://github.com/ScottKirvan/ReleasePleaseTest/issues/new) · 💬 [Discord](https://discord.gg/TN6XJSNK5Y)
     secrets: inherit
 
+  update-changelog-prs:
+    needs: release-please
+    if: ${{ needs.release-please.outputs.release_created }}
+    uses: ScottKirvan/.github/.github/workflows/reusable-update-changelog-prs.yml@main
+    with:
+      tag_name: ${{ needs.release-please.outputs.tag_name }}
+
   discord-notify:
     needs: [release-please, improve-release-notes]
     if: ${{ needs.release-please.outputs.release_created }}


### PR DESCRIPTION
Adds the `update-changelog-prs` reusable job (from `ScottKirvan/.github`) to the release workflow. After each release it queries GitHub for PRs merged since the previous tag and injects a `### Pull Requests` section into `notes/CHANGELOG.md`.